### PR TITLE
Allow static validator to run before prompt's validator.

### DIFF
--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -249,7 +249,7 @@ abstract class Prompt
     /**
      * Set the custom validation callback.
      */
-    public static function validateUsing(Closure $callback): void
+    public static function validateUsing(?Closure $callback): void
     {
         static::$validateUsing = $callback;
     }
@@ -403,8 +403,8 @@ abstract class Prompt
         }
 
         $error = match (true) {
-            is_callable($this->validate) => ($this->validate)($value),
             isset(static::$validateUsing) => (static::$validateUsing)($this),
+            is_callable($this->validate) => ($this->validate)($value),
             default => throw new RuntimeException('The validation logic is missing.'),
         };
 

--- a/tests/Feature/ConfirmPromptTest.php
+++ b/tests/Feature/ConfirmPromptTest.php
@@ -145,5 +145,5 @@ it('supports custom validation', function () {
 
     Prompt::assertOutputContains('Need to be sure!');
 
-    Prompt::validateUsing(fn () => null);
+    Prompt::validateUsing(null);
 });

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -354,7 +354,7 @@ it('supports custom validation', function () {
 
     Prompt::assertOutputContains('And green?');
 
-    Prompt::validateUsing(fn () => null);
+    Prompt::validateUsing(null);
 });
 
 it('supports selecting all options', function () {

--- a/tests/Feature/MultiSelectPromptTest.php
+++ b/tests/Feature/MultiSelectPromptTest.php
@@ -273,5 +273,5 @@ it('supports custom validation', function () {
 
     Prompt::assertOutputContains('And green?');
 
-    Prompt::validateUsing(fn () => null);
+    Prompt::validateUsing(null);
 });

--- a/tests/Feature/PasswordPromptTest.php
+++ b/tests/Feature/PasswordPromptTest.php
@@ -113,5 +113,5 @@ it('supports custom validation', function () {
 
     Prompt::assertOutputContains('Minimum 8 chars!');
 
-    Prompt::validateUsing(fn () => null);
+    Prompt::validateUsing(null);
 });

--- a/tests/Feature/SearchPromptTest.php
+++ b/tests/Feature/SearchPromptTest.php
@@ -210,5 +210,5 @@ it('supports custom validation', function () {
 
     Prompt::assertOutputContains('Please choose green.');
 
-    Prompt::validateUsing(fn () => null);
+    Prompt::validateUsing(null);
 });

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -364,5 +364,5 @@ it('supports custom validation', function () {
 
     Prompt::assertOutputContains('Please choose green.');
 
-    Prompt::validateUsing(fn () => null);
+    Prompt::validateUsing(null);
 });

--- a/tests/Feature/SuggestPromptTest.php
+++ b/tests/Feature/SuggestPromptTest.php
@@ -230,5 +230,5 @@ it('supports custom validation', function () {
 
     Prompt::assertOutputContains('Minimum 2 chars!');
 
-    Prompt::validateUsing(fn () => null);
+    Prompt::validateUsing(null);
 });

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -150,7 +150,7 @@ it('supports custom validation', function () {
 
     Prompt::assertOutputContains('Minimum 2 chars!');
 
-    Prompt::validateUsing(fn () => null);
+    Prompt::validateUsing(null);
 });
 
 it('allows customizing the cancellation', function () {


### PR DESCRIPTION
Laravel Prompts PR: https://github.com/laravel/prompts/pull/186

## Summary

Prompts allow to specify a validator for a prompt using `validate()` closure or static `$validateUsing` closure.

`Prompt::validate()` contains a `match()` with:
```php
$error = match (true) {
    is_callable($this->validate) => ($this->validate)($value),
    isset(static::$validateUsing) => (static::$validateUsing)($this),
    default => throw new RuntimeException('The validation logic is missing.'),
};
```

This will call the Prompt's validator before the static validator.

## Problem

When testing prompts (via PHPUnit or Pest) in consumer projects using interactive inputs, the prompt that has failed the validation will halt the test execution expecting an input.

To work around this, a test executor (PHPUnit in the example below), could override the handling of the incorrect validator to, for example, throw an exception instead of re-asking for an input, and then assert for that exception in the test:

```php
// Fake input.
Prompt::fake(['t', 'e', 's', 't', Key::ENTER]);

// Intercept handling of the validation by throwing an exception.
Prompt::validateUsing(function (Prompt $prompt) {
    if (is_callable($prompt->validate)) {
        $error = ($prompt->validate)($prompt->value()); // <--- similar to what Prompt::validate() does.
        
        // Intercepting and throwing an exception that will later be picked up by a test and would fail an assertion.
        if ($error) {
            throw new \RuntimeException(sprintf('Validation for "%s" failed with error "%s".', $prompt->label, $error));
        }
    }

    return NULL;
  });
  
// call the prompt  
...

// Assert for the exception.
...
```

Before this PR, the static `$validateUsing` will not be assessed if the Prompt's `validate()` closure is set, making it impossible to intercept the validation handling.

After this PR is merged, the static `$validateUsing` will take precedence and will allow to intercept the validation.

## Changes

1. Updated the order of validation callback checks to check for `static::$validateUsing`
2. Updated `validateUsing()` method to allow accepting `NULL` as a callback to allow resetting the value of `$validateUsing`. Note that the property value already allows to have a `NULL`'ified callback, so the changes to this setter follow that property type definition.
3. Updated tests that were setting the `static::$validateUsing` and then erroneously resetting the value using `fn() => null` to clear it: this was setting the value to an empty closure that would return a `NULL` instead of unsetting the callback completely, so the intended "resetting" was not working correctly resulting in "bleeding" of the `static::$validateUsing` into other tests; this was not picked up by tests until a change was made in this PR.